### PR TITLE
Support aggregate functions in queries

### DIFF
--- a/pysquril/generator.py
+++ b/pysquril/generator.py
@@ -300,8 +300,6 @@ class SqliteQueryGenerator(SqlGenerator):
             if term.original in ['*', '1']:
                 selection = '1'
         else:
-            #if term.func in ['avg', 'sum', 'min', 'max']:
-             #   selection = f"({selection})::int"
             if term.func.endswith('_ts'):
                 term.func = term.func.replace('_ts', '')
         return f"{term.func}({selection})"

--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -23,9 +23,8 @@ class BaseSelectElement(SelectElement):
     name = None
     regex = None
 
-    def __init__(self, element: str, func: Optional[str] = None) -> None:
+    def __init__(self, element: str) -> None:
         self.element = element
-        self.func = func
         self.bare_key = self.create_bare_key(self.element)
         self.sub_selections = self.create_sub_selections(self.element)
         self.idx = self.create_idx(self.element)
@@ -113,7 +112,7 @@ class SelectTerm(object):
                     if found:
                         msg = f'Could not uniquely identify {element} - already matched with {found}'
                         raise Exception(msg)
-                    element_instance = ElementClass(element, self.func)
+                    element_instance = ElementClass(element)
                     found = ElementClass.name
             if not element_instance:
                 raise Exception(f'Could not parse {element}')

--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -19,14 +19,22 @@ class SelectElement(ABC):
 
 
 class BaseSelectElement(SelectElement):
+
     name = None
     regex = None
+
     def __init__(self, element: str) -> None:
         self.element = element
+        self.bare_key = self.create_bare_key(element)
+        self.sub_selections = self.create_sub_selections(element)
+        self.idx = self.create_idx(element)
+
     def create_bare_key(self, element: str) -> Optional[list]:
         return element.split('[')[0] if '[' in element else None
+
     def create_sub_selections(self, element: str) -> list:
         return element.split('|')[1].replace(']', '').split(',') if '|' in element else []
+
     def create_idx(self, element: str) -> Optional[str]:
         if '[' in element and '|' in element:
             return re.sub(r'.+\[(.*)\|(.*)\]', r'\1', element)
@@ -35,64 +43,35 @@ class BaseSelectElement(SelectElement):
         else:
             return None
 
+
 class Key(BaseSelectElement):
     name = 'key'
     regex = r'[^\[\]]+$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class ArraySpecific(BaseSelectElement):
     name = 'array.specific'
     regex = r'.+\[[0-9]+\]$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class ArraySpecificSingle(BaseSelectElement):
     name = 'array.specific.single'
     regex = r'.+\[[0-9]+\|[^,]+\]$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class ArraySpecificMultiple(BaseSelectElement):
     name = 'array.specific.multiple'
     regex = r'.+\[[0-9]+\|.+,.+\]$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class ArrayBroadcastSingle(BaseSelectElement):
     name = 'array.broadcast.single'
     regex = r'.+\[\*\|[^,]+\]$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class ArrayBroadcastMultiple(BaseSelectElement):
     name = 'array.broadcast.multiple'
     regex = r'.+\[\*\|.+,.+\]$'
-    def __init__(self, element: str) -> None:
-        self.element = element
-        self.bare_key = self.create_bare_key(element)
-        self.sub_selections = self.create_sub_selections(element)
-        self.idx = self.create_idx(element)
 
 
 class SelectTerm(object):

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -189,9 +189,11 @@ class TestBackends(object):
         db = DbBackendCls(engine)
         try:
             db.table_delete('test_table', '')
+            db.table_delete('another_table', '')
         except Exception as e:
             pass
         db.table_insert('test_table', data)
+        db.table_insert('another_table', data)
 
         # SELECT
         if verbose:
@@ -277,6 +279,10 @@ class TestBackends(object):
         assert out == [[1]]
         out = run_select_query('select=max(q.r[0|s])')
         assert out == [[77]]
+
+        # broadcasting aggregations
+        out = list(db.table_select('*', 'select=count(1)', exclude_endswith = ['_audit', '_metadata']))
+        assert out == [{'another_table': [5]}, {'test_table': [5]}]
 
         # WHERE
         if verbose:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pysquril',
-    version='0.0.1',
+    version='0.1.0',
     description='Structured query URI language',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',


### PR DESCRIPTION
This allows fetching e.g. the number of entries and the timestamp of the latest entry for _all_ endpoints in one request: `/v1/{pnum}/survey/*/submissions?select=count(*),max_ts(metadata.created)`. See the tests for more examples.