### PR TITLE
fix generator update

### DIFF
--- a/pysquril/generator.py
+++ b/pysquril/generator.py
@@ -530,5 +530,5 @@ class PostgresQueryGenerator(SqlGenerator):
         key = term.parsed[0].select_term.bare_term
         assert self.data.get(key) is not None, f'Target key of update: {key} not found in payload'
         assert len(self.data.keys()) == 1, f'Cannot update more than one key per statement'
-        val = self.data[key]
+        val = json.dumps(self.data[key])
         return f"set data = jsonb_set(data, '{{{key}}}', '{val}')"

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -359,6 +359,10 @@ class TestBackends(object):
         out = run_select_query('select=x&where=x=eq.999')
         assert out[0][0] == 999
         assert len(out) == 3
+        out = run_update_query('set=a&where=a.k1.r2=eq.90', data={'a': {'k1': {'r1': [33, 200], 'r2': 80 }}})
+        out = run_select_query('where=a.k1.r2=eq.80')
+        assert len(out) == 1
+        assert out[0]['a']['k1']['r2'] == 80
 
         # DELETE
         if verbose:


### PR DESCRIPTION
_gen_sql_update is using dict instead of string as argument to jsonb_set which triggers a syntax error.

![Selection_018](https://user-images.githubusercontent.com/11461352/191715134-86de6b5d-c674-46f2-a5db-89ba1eeca0f1.png)
