### PR TITLE
SqliteBackend fixes and audit functionality testing

### DIFF
--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -201,7 +201,7 @@ class SqliteBackend(DatabaseBackend):
 
     def table_update(self, table_name: str, uri_query: str, data: dict) -> bool:
         old = list(self.table_select(table_name, uri_query, data=data))
-        sql = self.generator_class(f"{self.schema}{self.sep}{table_name}", uri_query, data=data)
+        sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query, data=data)
         with sqlite_session(self.engine) as session:
             session.execute(sql.update_query)
         audit_data = []
@@ -216,7 +216,7 @@ class SqliteBackend(DatabaseBackend):
         return True
 
     def table_delete(self, table_name: str, uri_query: str) -> bool:
-        sql = self.generator_class(f"{self.schema}{self.sep}{table_name}", uri_query)
+        sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query)
         with sqlite_session(self.engine) as session:
             try:
                 session.execute(sql.delete_query)
@@ -224,7 +224,7 @@ class SqliteBackend(DatabaseBackend):
                 logging.error(f'Syntax error?: {sql.delete_query}')
                 raise e
         if not uri_query:
-            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}_audit', uri_query)
+            sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}_audit"', uri_query)
             try:
                 with sqlite_session(self.engine) as session:
                     session.execute(sql.delete_query)
@@ -235,7 +235,7 @@ class SqliteBackend(DatabaseBackend):
     def _union_queries(self, uri_query: str, tables: list) -> str:
         queries = []
         for table_name in tables:
-            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}', uri_query)
+            sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query)
             queries.append(f"select json_object('{self.schema}{self.sep}{table_name}', ({sql.select_query}))")
         return " union all ".join(queries)
 
@@ -246,7 +246,7 @@ class SqliteBackend(DatabaseBackend):
                 return iter([])
             query = self._union_queries(uri_query, tables)
         else:
-            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}', uri_query, data=data)
+            sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query, data=data)
             query = sql.select_query
         with sqlite_session(self.engine) as session:
             for row in session.execute(query):

--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -167,7 +167,7 @@ class SqliteBackend(DatabaseBackend):
     def table_insert(self, table_name: str, data: Union[dict, list]) -> bool:
         try:
             dtype = type(data)
-            insert_stmt = f'insert into "{table_name}" (data) values (?)'
+            insert_stmt = f'insert into {self.schema}."{table_name}" (data) values (?)'
             target = []
             if dtype is list:
                 for element in data:
@@ -180,7 +180,7 @@ class SqliteBackend(DatabaseBackend):
                 return True
             except (sqlite3.ProgrammingError, sqlite3.OperationalError) as e:
                 with sqlite_session(self.engine) as session:
-                    session.execute(f'create table if not exists "{table_name}" {self.table_definition}')
+                    session.execute(f'create table if not exists {self.schema}."{table_name}" {self.table_definition}')
                     session.executemany(insert_stmt, target)
                 return True
         except sqlite3.IntegrityError as e:
@@ -198,7 +198,7 @@ class SqliteBackend(DatabaseBackend):
 
     def table_update(self, table_name: str, uri_query: str, data: dict) -> bool:
         old = list(self.table_select(table_name, uri_query))
-        sql = self.generator_class(f'"{table_name}"', uri_query, data=data)
+        sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query, data=data)
         with sqlite_session(self.engine) as session:
             session.execute(sql.update_query)
         audit_data = []
@@ -209,11 +209,11 @@ class SqliteBackend(DatabaseBackend):
                 'previous': val,
                 'identity': self.requestor
             })
-        self.table_insert(f'{table_name}_audit', audit_data)
+        self.table_insert(f'{self.schema}.{table_name}_audit', audit_data)
         return True
 
     def table_delete(self, table_name: str, uri_query: str) -> bool:
-        sql = self.generator_class(f'"{table_name}"', uri_query)
+        sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)
         with sqlite_session(self.engine) as session:
             try:
                 session.execute(sql.delete_query)
@@ -232,8 +232,8 @@ class SqliteBackend(DatabaseBackend):
     def _union_queries(self, uri_query: str, tables: list) -> str:
         queries = []
         for table_name in tables:
-            sql = self.generator_class(f'"{table_name}"', uri_query)
-            queries.append(f"select json_object('{table_name}', ({sql.select_query}))")
+            sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)
+            queries.append(f"select json_object({self.schema}.'{table_name}', ({sql.select_query}))")
         return " union all ".join(queries)
 
     def table_select(self, table_name: str, uri_query: str, exclude_endswith: list = []) -> Iterable[tuple]:
@@ -241,7 +241,7 @@ class SqliteBackend(DatabaseBackend):
             tables = self.tables_list(exclude_endswith = exclude_endswith)
             query = self._union_queries(uri_query, tables)
         else:
-            sql = self.generator_class(f'"{table_name}"', uri_query)
+            sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)
             query = sql.select_query
         with sqlite_session(self.engine) as session:
             for row in session.execute(query):

--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -125,6 +125,7 @@ class SqliteBackend(DatabaseBackend):
     """
 
     generator_class = SqliteQueryGenerator
+    sep = "_"
 
     def __init__(
         self,
@@ -167,7 +168,7 @@ class SqliteBackend(DatabaseBackend):
     def table_insert(self, table_name: str, data: Union[dict, list]) -> bool:
         try:
             dtype = type(data)
-            insert_stmt = f'insert into {self.schema}."{table_name}" (data) values (?)'
+            insert_stmt = f'insert into "{self.schema}{self.sep}{table_name}" (data) values (?)'
             target = []
             if dtype is list:
                 for element in data:
@@ -180,7 +181,7 @@ class SqliteBackend(DatabaseBackend):
                 return True
             except (sqlite3.ProgrammingError, sqlite3.OperationalError) as e:
                 with sqlite_session(self.engine) as session:
-                    session.execute(f'create table if not exists {self.schema}."{table_name}" {self.table_definition}')
+                    session.execute(f'create table if not exists "{self.schema}{self.sep}{table_name}" {self.table_definition}')
                     session.executemany(insert_stmt, target)
                 return True
         except sqlite3.IntegrityError as e:
@@ -198,7 +199,7 @@ class SqliteBackend(DatabaseBackend):
 
     def table_update(self, table_name: str, uri_query: str, data: dict) -> bool:
         old = list(self.table_select(table_name, uri_query, data=data))
-        sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query, data=data)
+        sql = self.generator_class(f"{self.schema}{self.sep}{table_name}", uri_query, data=data)
         with sqlite_session(self.engine) as session:
             session.execute(sql.update_query)
         audit_data = []
@@ -209,11 +210,11 @@ class SqliteBackend(DatabaseBackend):
                 'previous': val,
                 'identity': self.requestor
             })
-        self.table_insert(f'{self.schema}.{table_name}_audit', audit_data)
+        self.table_insert(f'{self.schema}{self.sep}{table_name}_audit', audit_data)
         return True
 
     def table_delete(self, table_name: str, uri_query: str) -> bool:
-        sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)
+        sql = self.generator_class(f"{self.schema}{self.sep}{table_name}", uri_query)
         with sqlite_session(self.engine) as session:
             try:
                 session.execute(sql.delete_query)
@@ -221,7 +222,7 @@ class SqliteBackend(DatabaseBackend):
                 logging.error(f'Syntax error?: {sql.delete_query}')
                 raise e
         if not uri_query:
-            sql = self.generator_class(f'{self.schema}."{table_name}_audit"', uri_query)
+            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}_audit', uri_query)
             try:
                 with sqlite_session(self.engine) as session:
                     session.execute(sql.delete_query)
@@ -232,8 +233,8 @@ class SqliteBackend(DatabaseBackend):
     def _union_queries(self, uri_query: str, tables: list) -> str:
         queries = []
         for table_name in tables:
-            sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)
-            queries.append(f"select json_object({self.schema}.'{table_name}', ({sql.select_query}))")
+            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}', uri_query)
+            queries.append(f"select json_object('{self.schema}{self.sep}{table_name}', ({sql.select_query}))")
         return " union all ".join(queries)
 
     def table_select(self, table_name: str, uri_query: str, data: Optional[Union[dict, list]] = None, exclude_endswith: list = []) -> Iterable[tuple]:
@@ -243,7 +244,7 @@ class SqliteBackend(DatabaseBackend):
                 return iter([])
             query = self._union_queries(uri_query, tables)
         else:
-            sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query, data=data)
+            sql = self.generator_class(f'{self.schema}{self.sep}{table_name}', uri_query, data=data)
             query = sql.select_query
         with sqlite_session(self.engine) as session:
             for row in session.execute(query):

--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -125,7 +125,6 @@ class SqliteBackend(DatabaseBackend):
     """
 
     generator_class = SqliteQueryGenerator
-    sep = "_"
 
     def __init__(
         self,
@@ -137,7 +136,8 @@ class SqliteBackend(DatabaseBackend):
         self.engine = engine
         self.verbose = verbose
         self.table_definition = '(data json unique not null)'
-        self.schema = schema if schema else 'public'
+        self.schema = schema if schema else ""
+        self.sep = "_" if self.schema else ""
         self.requestor = requestor
 
     def initialise(self) -> Optional[bool]:

--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -210,7 +210,7 @@ class SqliteBackend(DatabaseBackend):
                 'previous': val,
                 'identity': self.requestor
             })
-        self.table_insert(f'{self.schema}{self.sep}{table_name}_audit', audit_data)
+        self.table_insert(f'{table_name}_audit', audit_data)
         return True
 
     def table_delete(self, table_name: str, uri_query: str) -> bool:

--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -239,6 +239,8 @@ class SqliteBackend(DatabaseBackend):
     def table_select(self, table_name: str, uri_query: str, exclude_endswith: list = []) -> Iterable[tuple]:
         if table_name == "*":
             tables = self.tables_list(exclude_endswith = exclude_endswith)
+            if not tables:
+                return iter([])
             query = self._union_queries(uri_query, tables)
         else:
             sql = self.generator_class(f'{self.schema}."{table_name}"', uri_query)

--- a/pysquril/generator.py
+++ b/pysquril/generator.py
@@ -416,7 +416,7 @@ class SqliteQueryGenerator(SqlGenerator):
 
     def _gen_sql_update(self, term: SetTerm) -> str:
         key = term.parsed[0].select_term.bare_term
-        if self.data.get(key) is None:
+        if not self.data or self.data.get(key) is None:
             raise ParseError(f'Target key of update: {key} not found in payload')
         new = json.dumps(self.data)
         return f"set data = json_patch(data, '{new}')"


### PR DESCRIPTION
* Add test of audit functionality ed7635fa6f687ac21d4ed594adbe3861786a309d
* Simulate schema in SqliteBackend f0660352b5b8d1f8e999e5a860788e8177600aec, a9277ab7a432ce3ac64a99b7113f3396258cc529
* Add zero tables fix from PostgresBackend d7a1aa61b7691f1eda599e0124a4e9a6f32738e5
* `table_select()` now optionally takes `data` parameter