### PR TITLE
Add optional audit messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysquril"
-version = "0.3.5"
+version = "0.3.6"
 description = "Python implementation of structured URI query language"
 readme = "README.md"
 repository = "https://github.com/unioslo/pysquril"

--- a/pysquril/generator.py
+++ b/pysquril/generator.py
@@ -59,6 +59,7 @@ class SqlGenerator(object):
         self.select_query = self.sql_select()
         self.update_query = self.sql_update()
         self.delete_query = self.sql_delete()
+        self.message = self.uri_message()
 
     # Classes that extend the SqlGenerator must implement the following methods
     # they are called by functions that are mapped over terms in clauses
@@ -320,6 +321,9 @@ class SqlGenerator(object):
         else:
             query = f"delete from {self.table_name} {_where}"
         return query
+
+    def uri_message(self) -> str:
+        return self.parsed_uri_query.message
 
 
 class SqliteQueryGenerator(SqlGenerator):

--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -6,6 +6,7 @@ import re
 
 from abc import ABC, abstractmethod
 from typing import Optional, Union, Callable
+from urllib.parse import unquote
 
 from pysquril.exc import ParseError
 
@@ -325,6 +326,15 @@ class UriQuery(object):
         self.order = self.parse_clause(prefix='order=', Cls=OrderClause)
         self.range = self.parse_clause(prefix='range=', Cls=RangeClause)
         self.set = self.parse_clause(prefix='set=', Cls=SetClause)
+        self.message = self.parse_message()
+
+    def parse_message(self) -> str:
+        message = ""
+        parts = self.original.split("&")
+        for part in parts:
+            if part.startswith("message="):
+                message = unquote(part.split("=")[-1])
+        return message
 
     def parse_clause(self, *, prefix: str, Cls: Clause) -> Clause:
         if not prefix:


### PR DESCRIPTION
With this change the audit becomes much more valuable, since it can now indicate: what changed, when, who changed it, and crucially, _why_ the change was made.

* messages are optional
* supplied in the URI
* the message itself must be URI encoded
* applies to all audit events: update, delete, restore
* bump minor version
