### PR TITLE
Support limiting access to audit data and restore functionality via a retention period

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python implementation of structured URI query language.
 
 ```bash
 poetry install
-poetry run python pytest pysquril/tests.py
+poetry run pytest pysquril/tests.py
 ```
 
 ## License


### PR DESCRIPTION
If the implementations of the `GenericBackend` are constructed with `backup_days` set, then in the case where the source table has been deleted it will:
* filter out all audit entries that are older than the current timestamp minus the amount of days
* subsequently not enable restoring entries falling outside the specified retention period

This functionality, therefore, allows specifying a backup period on table deletion, such as 90 days. This only applies to deletion of entire tables (i.e. `drop table ...`), not the deletion of rows from a table (`delete from ...`).