### PR TITLE
Support fuzzy matching of table names, along with using non-aggregate queries

### DIFF
--- a/pysquril/backends.py
+++ b/pysquril/backends.py
@@ -513,7 +513,7 @@ class SqliteBackend(GenericBackend):
     def _union_queries(self, uri_query: str, tables: list) -> str:
         queries = []
         for table_name in tables:
-            sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query)
+            sql = self.generator_class(f'"{self.schema}{self.sep}{table_name}"', uri_query, array_agg=True)
             queries.append(f"select json_object('{self.schema}{self.sep}{table_name}', ({sql.select_query}))")
         return " union all ".join(queries)
 
@@ -725,7 +725,7 @@ class PostgresBackend(GenericBackend):
     def _union_queries(self, uri_query: str, tables: list) -> str:
         queries = []
         for table_name in tables:
-            sql = self.generator_class(f'{self.schema}{self.sep}"{table_name}"', uri_query)
+            sql = self.generator_class(f'{self.schema}{self.sep}"{table_name}"', uri_query, array_agg=True)
             queries.append(f"select jsonb_build_object('{table_name}', ({sql.select_query}))")
         return " union all ".join(queries)
 

--- a/pysquril/generator.py
+++ b/pysquril/generator.py
@@ -161,7 +161,6 @@ class SqlGenerator(object):
     def _term_to_sql_select(self, term: SelectTerm) -> str:
         rev = term.parsed.copy()
         rev.reverse()
-        out = []
         first_done = False
         for parsed in rev:
             if isinstance(parsed, Key):

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -255,6 +255,19 @@ class TestBackends(object):
         out = list(db.table_select('*_table', 'select=count(1)', exclude_endswith = ['_audit', '_metadata']))
         assert out == [{'another_table': [5]}, {'test_table': [5]}]
 
+        # broadcasting queries without aggregation
+        out = list(db.table_select('*', 'select=x', exclude_endswith = ['_audit', '_metadata']))
+        assert out is not None
+        assert len(out) == 2
+        assert len(out[0].get("another_table")) == 5
+        assert len(out[1].get("test_table")) == 5
+
+        out = list(db.table_select('*', 'select=x,y&where=z=not.is.null', exclude_endswith = ['_audit', '_metadata']))
+        assert out is not None
+        assert len(out) == 2
+        assert len(out[0].get("another_table")) == 4
+        assert len(out[1].get("test_table")) == 4
+
         # WHERE
         if verbose:
             print('\n===> WHERE\n')

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -242,6 +242,13 @@ class TestBackends(object):
         out = list(db.table_select('*', 'select=count(1)', exclude_endswith = ['_audit', '_metadata']))
         assert out == [{'another_table': [5]}, {'test_table': [5]}]
 
+        # fuzzy matching
+        out = list(db.table_select('another*', 'select=count(1)', exclude_endswith = ['_audit', '_metadata']))
+        assert out == [{'another_table': [5]}]
+
+        out = list(db.table_select('*_table', 'select=count(1)', exclude_endswith = ['_audit', '_metadata']))
+        assert out == [{'another_table': [5]}, {'test_table': [5]}]
+
         # WHERE
         if verbose:
             print('\n===> WHERE\n')


### PR DESCRIPTION
Addresses: https://github.com/unioslo/pysquril/issues/39

Suppose you have a set of tables: 

```txt
/tables/system_lol
/tables/system_cat
/tables/system_lollypop
```

Which contain data associated with risk analyses for different systems as such:

```json
{"risk_element": "bla", "risk_score": 1, "todos": null}
{"risk_element": "blabla", "risk_score": 5, "todos": ["something"]}
{"risk_element": "blablabla", "risk_score": 6, "todos": ["all things"]}
```

With this PR, you can now do an API call such as `GET /tables/*lol*?select=risk_element,todos&where=score=gte.5` to fetch all high risk elements across different tables/risk analyses, which will return e.g.:

```json
{
  "system_lol": [["blabla", ["something"]], ["blablabla", ["all things"]]], 
  "system_lollypop": [["blabla", ["something"]], ["blablabla", ["all things"]]]
}
``` 

So the new features are:
* fuzzy matching of names to determine which tables to apply a query to
* applying any query to such cross-table calls (not just aggregations like before)
