### PR TITLE
Support altering table name

### DIFF
--- a/pysquril/exc.py
+++ b/pysquril/exc.py
@@ -12,3 +12,6 @@ class ParseError(PySqurilError):
 
 class DataIntegrityError(PySqurilError):
     status = HTTPStatus.BAD_REQUEST
+
+class OperationNotPermittedError(PySqurilError):
+    status = HTTPStatus.BAD_REQUEST

--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -346,6 +346,9 @@ class SetClause(Clause):
 class GroupByClause(Clause):
     term_class = SelectTerm
 
+class AlterClause(Clause):
+    term_class = WhereTerm
+
 class UriQuery(object):
 
     """
@@ -372,6 +375,7 @@ class UriQuery(object):
         self.order = self.parse_clause(prefix='order=', Cls=OrderClause)
         self.range = self.parse_clause(prefix='range=', Cls=RangeClause)
         self.set = self.parse_clause(prefix='set=', Cls=SetClause)
+        self.alter = self.parse_clause(prefix='alter=', Cls=AlterClause)
         self.group_by = self.parse_clause(prefix='group_by=', Cls=GroupByClause)
         self.message = self.parse_message()
         if self.group_by:

--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -294,6 +294,7 @@ class Clause(object):
     def __init__(self, original: str) -> None:
         self.original = original
         self.parsed = self.parse_terms()
+        self._enforce_constraints()
 
     def split_clause(self) -> list:
         braces_open = False
@@ -327,6 +328,14 @@ class Clause(object):
             out.append(self.term_class(term))
         return out
 
+    def _enforce_constraints(self) -> None:
+        """
+        Implemented if the specific clause must enforce
+        contraints not shared by all.
+
+        """
+        pass
+
 
 class SelectClause(Clause):
     term_class = SelectTerm
@@ -348,6 +357,19 @@ class GroupByClause(Clause):
 
 class AlterClause(Clause):
     term_class = WhereTerm
+
+    def _enforce_constraints(self) -> None:
+        """
+        Only rename is supported thus far.
+
+        """
+        term = self.parsed[0]
+        element = term.parsed[0]
+        if element.select_term.bare_term != "name":
+            raise ParseError("alter statements limited to `name` attribute")
+        if element.op != "eq":
+            raise ParseError(f"rename requires `eq` operator, not {element.op}")
+
 
 class UriQuery(object):
 

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -21,7 +21,7 @@ from termcolor import colored
 from pysquril.backends import SqliteBackend, PostgresBackend, sqlite_session, postgres_session
 from pysquril.exc import ParseError
 from pysquril.generator import SqliteQueryGenerator, PostgresQueryGenerator
-from pysquril.parser import SelectClause, WhereClause, GroupByTerm, GroupByClause
+from pysquril.parser import SelectClause, WhereClause, GroupByTerm, GroupByClause, AlterClause
 from pysquril.test_data import dataset
 
 def sqlite_init(
@@ -72,7 +72,6 @@ class TestParser(object):
         c = WhereClause("a=gte.4,and:b=eq.'r,[,],',or:c=neq.0")
         assert len(c.split_clause()) == 3
 
-
     def test_group_by(self) -> None:
 
         with pytest.raises(ParseError):
@@ -92,6 +91,12 @@ class TestParser(object):
 
         c = GroupByClause("a.b.c,d")
         assert len(c.split_clause()) == 2
+
+    def test_alter(self) -> None:
+        c = AlterClause("name=eq.new_name")
+        term = c.parsed[0]
+        element = term.parsed[0]
+        assert element.val == "new_name"
 
 
 class TestBackends(object):
@@ -478,6 +483,8 @@ class TestBackends(object):
         with pytest.raises(Exception):
             out = run_delete_query('')
 
+        # ALTER
+        # table_name?alter=name=eq.new_name
 
 
     def test_sqlite(self):

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -93,10 +93,17 @@ class TestParser(object):
         assert len(c.split_clause()) == 2
 
     def test_alter(self) -> None:
+
         c = AlterClause("name=eq.new_name")
         term = c.parsed[0]
         element = term.parsed[0]
         assert element.val == "new_name"
+
+        with pytest.raises(ParseError):
+            AlterClause("num=eq.new_name")
+
+        with pytest.raises(ParseError):
+            AlterClause("name=neq.new_name")
 
 
 class TestBackends(object):


### PR DESCRIPTION
When altering a table named `A` to `B`, `A_audit` will become `B_audit`, if it exists.

Ref: https://github.com/unioslo/pysquril/issues/43


