### PR TITLE
Add support for nested updates

### DIFF
--- a/pysquril/parser.py
+++ b/pysquril/parser.py
@@ -418,6 +418,8 @@ class SetClause(Clause):
                     key != "*"
                     and isinstance(self.data, dict)
                     and key not in self.data.keys()
+                    and len(terms) == 1
+                    and isinstance(terms[0], Key)
                 ):
                     raise ParseError(f'Target key of update: {key} not found in payload')
 

--- a/pysquril/tests.py
+++ b/pysquril/tests.py
@@ -235,6 +235,27 @@ class TestParser(object):
 
         SetClause("*", {"new": "data"})
 
+        # nested updates
+
+        # supported
+
+        SetClause("a.b", "3")
+
+        SetClause("a.b.c[1]", "2")
+
+        SetClause("a[1|h]", "1")
+
+        # not supported
+
+        with pytest.raises(ParseError):
+            SetClause("a[*|h]", "1")
+
+        with pytest.raises(ParseError):
+            SetClause("a[1|h,j]", "1")
+
+        with pytest.raises(ParseError):
+            SetClause("a[*|h,j]", "1")
+
 
     def test_restore(self) -> None:
 


### PR DESCRIPTION
Given `{"a": {"b": 1}, "c": [1, 2], "d": [{"x": 4, "y": 6}]}`, the new functionality allows you to update, e.g.: `set=a.b`, `set=c[0]`, and `set=d[0|x]` to the value of choice, without having to provide the entire key/value as payload.

Addresses: https://github.com/unioslo/pysquril/issues/78 